### PR TITLE
adds new call style with tests

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -46,35 +46,14 @@ describe('hc-web-client call', () => {
 
   it('produces the expected call object when called with three params', async () => {
     const testUrl = 'ws://localhost:3000'
-    const { call } = await connect(testUrl)
-    await call('instance', 'zome', 'func')({param1: 'x'})
+    const { callZome } = await connect(testUrl)
+    await callZome('instance', 'zome', 'func')({param1: 'x'})
     expect(callMock).toBeCalledWith('call', {
       'instance_id': 'instance',
       'zome': 'zome',
       'function': 'func',
       'params': {param1: 'x'}
     })
-  })
-
-  it('produces the expected call object when called with one slash delimited string', async () => {
-    const testUrl = 'ws://localhost:3000'
-    const { call } = await connect(testUrl)
-    await call('instance/zome/func')({param2: 'y'})
-    expect(callMock).toBeCalledWith('call', {
-      'instance_id': 'instance',
-      'zome': 'zome',
-      'function': 'func',
-      'params': {param2: 'y'}
-    })
-  })
-
-  it('throws the expected error when called with 2 params', async () => {
-    const testUrl = 'ws://localhost:3000'
-    const { call } = await connect(testUrl)
-    expect(call('instance', 'zome')).toThrow('Invalid params to call. \
-          Must be either 3 string spefifying instance, zome, function \
-          or a single string delimited with "/"')
-    
   })
 
 })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,19 +1,24 @@
 import { connect } from '../index'
 import { Client } from 'rpc-websockets'
 
+const callMock = jest.fn()
+
 jest.mock('rpc-websockets', () => {
   return {
     Client: jest.fn(() => {
       return {
         on: jest.fn((on, callback) => {
           return callback()
-        })
+        }),
+        call: jest.fn((method, params) => {
+          callMock(method, params)
+        }),
       }
     })
   }
 })
 
-describe('hc-web-client', () => {
+describe('hc-web-client connect', () => {
 
   it('Can connect by passing URL', async () => {
     const testUrl = 'ws://localhost:3000'
@@ -33,6 +38,34 @@ describe('hc-web-client', () => {
     // @ts-ignore
     fetch.mockResponseOnce(JSON.stringify({ }))
     expect(connect()).rejects.toEqual(`Could not auto-detect DNA interface from conductor. Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect`)
+  })
+
+})
+
+describe('hc-web-client call', () => {
+
+  it('produces the expected call object when called with three params', async () => {
+    const testUrl = 'ws://localhost:3000'
+    const { call } = await connect(testUrl)
+    await call('instance', 'zome', 'func')({param1: 'x'})
+    expect(callMock).toBeCalledWith('call', {
+      'instance_id': 'instance',
+      'zome': 'zome',
+      'function': 'func',
+      'params': {param1: 'x'}
+    })
+  })
+
+  it('produces the expected call object when called with one slash delimited string', async () => {
+    const testUrl = 'ws://localhost:3000'
+    const { call } = await connect(testUrl)
+    await call('instance/zome/func')({param2: 'y'})
+    expect(callMock).toBeCalledWith('call', {
+      'instance_id': 'instance',
+      'zome': 'zome',
+      'function': 'func',
+      'params': {param2: 'y'}
+    })
   })
 
 })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -68,4 +68,13 @@ describe('hc-web-client call', () => {
     })
   })
 
+  it('throws the expected error when called with 2 params', async () => {
+    const testUrl = 'ws://localhost:3000'
+    const { call } = await connect(testUrl)
+    expect(call('instance', 'zome')).toThrow('Invalid params to call. \
+          Must be either 3 string spefifying instance, zome, function \
+          or a single string delimited with "/"')
+    
+  })
+
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,28 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
   const ws = new Client(url)
   ws.on('open', () => {
     const call = (...methodSegments) => (params) => {
-      const method = methodSegments.length === 1 ? methodSegments[0] : methodSegments.join('/')
-      return ws.call(method, params)
+      let instanceId
+      let zome
+      let func
+
+      if (methodSegments.length === 1) {
+        [instanceId, zome, func] = methodSegments[0].split('/')
+      } else if (methodSegments.length === 3) {
+        [instanceId, zome, func] = methodSegments
+      } else {
+        throw new Error('Invalid params to call. \
+          Must be either 3 string spefifying instance, zome, function \
+          or a single string delimited with "/"')
+      }
+
+      const callObject = {
+        'instance_id': instanceId,
+        zome,
+        'function': func,
+        params
+      }
+
+      return ws.call('call', callObject)
     }
     // define a function which will close the websocket connection
     const close = () => ws.close()

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
         [instanceId, zome, func] = methodSegments
       } else {
         throw new Error('Invalid params to call. \
-          Must be either 3 string spefifying instance, zome, function \
+          Must be either 3 string specifying instance, zome, function \
           or a single string delimited with "/"')
       }
 


### PR DESCRIPTION
All calls to holochain are now made to a single RPC method `call`.

The parameters to this `call` method define which holochain instance, zome and function to call and what parameters should be passed to that.

This PR adds the new format and tests