### PR TITLE
Add an onSignal function which allows javascript callbacks to be executed on receiving a signal

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "lint": "tslint -p tsconfig.json",
     "prepublishOnly": "npm test && npm run lint",
+    "prepare": "npm run build",
     "preversion": "npm run lint",
     "version": "git add -A src",
     "postversion": "git push && git push --tags",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ type ConnectOpts = {
  *       socket to be ready before timing out and rejecting the promise. Defaults to 5 seconds, but if you set it
  *       to 0 or null, it will never timeout.
  */
-export const connect = (opts: ConnectOpts) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
+export const connect = (opts: ConnectOpts = {}) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
   const url = opts.url || await getUrlFromContainer().catch(() => reject(
     'Could not auto-detect DNA interface from conductor. \
 Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,23 @@ type Close = () => Promise<any>
 type ConnectOpts = {
   url?: string,
   timeout?: number,
+  wsClient?: any,
 }
 
+/**
+ * Establish a websocket connection to a Conductor interface
+ * Accepts an object of options:
+ *   - url (optional): Specifies the URL to establish the connection with
+ *   - wsClient (optional): Object of options that gets passed through as configuration to the rpc-websockets client
+ *   - timeout (optional): If the socket is not ready, `call` and `callZome` will wait this many milliseconds for the
+ *       socket to be ready before timing out and rejecting the promise.
+ */
 export const connect = (opts: ConnectOpts) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
   const url = opts.url || await getUrlFromContainer().catch(() => reject(
     'Could not auto-detect DNA interface from conductor. \
 Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect'))
   const timeout = opts.timeout || DEFAULT_TIMEOUT
-  const ws = new Client(url)
+  const ws = new Client(url, opts.wsClient)
 
   ws.on('open', () => 'WS open')
   ws.on('close', () => 'WS closed')

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,14 @@ export const connect = (paramUrl?: string) => new Promise<{call: Call, callZome:
 Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect'))
 
   const ws = new Client(url)
-  ws.on('open', () => {
+
+  ws.on('open', () => 'WS open')
+  ws.on('close', () => 'WS closed')
+
+  ws.once('open', () => {
     const call = (...methodSegments) => (params) => {
       const method = methodSegments.length === 1 ? methodSegments[0] : methodSegments.join('/')
-      return ws.call(method, params)
+      return callWhenConnected(ws, method, params)
     }
     const callZome = (instanceId, zome, func) => (params) => {
       const callObject = {
@@ -25,7 +29,7 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
         'function': func,
         params
       }
-      return ws.call('call', callObject)
+      return callWhenConnected(ws, 'call', callObject)
     }
     const onSignal: OnSignal = (callback: (params: any) => void) => {
       // go down to the underlying websocket connection (.socket)
@@ -50,5 +54,26 @@ function getUrlFromContainer (): Promise<string> {
     .then(json => json.dna_interface.driver.port)
     .then(port => `ws://localhost:${port}`)
 }
+
+/**
+ * Ensure that a ws client never attempts to call when the socket is not ready
+ * Instead, return a promise that resolves only when the socket is connected and the call is made
+ */
+async function callWhenConnected (ws, method, payload, timeout=3000) {
+  if (ws.ready) {
+    return Promise.resolve(ws.call(method, payload))
+  } else {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(`Timeout while waiting for ws to connect. method: ${method}, payload: ${JSON.stringify(payload)}`)
+      }, timeout)
+      ws.once('open', () => {
+        clearTimeout(timer)
+        ws.call(method, payload).then(resolve).catch(reject)
+      })
+    })
+  }
+}
+
 
 const holochainclient = { connect }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ type ConnectOpts = {
  *   - url (optional): Specifies the URL to establish the connection with
  *   - wsClient (optional): Object of options that gets passed through as configuration to the rpc-websockets client
  *   - timeout (optional): If the socket is not ready, `call` and `callZome` will wait this many milliseconds for the
- *       socket to be ready before timing out and rejecting the promise.
+ *       socket to be ready before timing out and rejecting the promise. Defaults to 5 seconds, but if you set it
+ *       to 0 or null, it will never timeout.
  */
 export const connect = (opts: ConnectOpts) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
   const url = opts.url || await getUrlFromContainer().catch(() => reject(

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,13 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
       return ws.call('call', callObject)
     }
     const onSignal: OnSignal = (callback: (params: any) => void) => {
-      ws.on('message', (message: any) => {
-        if (message && message.signal) {
-          callback(message.signal)
+      // go down to the underlying websocket connection (.socket)
+      // for a simpler API
+      ws.socket.on('message', (message: any) => {
+        if (!message) return
+        const msg = JSON.parse(message)
+        if (msg.signal) {
+          callback(msg.signal)
         }
       })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,13 +28,9 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
       return ws.call('call', callObject)
     }
     const onSignal: OnSignal = (callback: (params: any) => void) => {
-      // go down to the underlying websocket connection (.socket)
-      // for a simpler API
-      ws.socket.on('message', (message: any) => {
-        if (!message) return
-        const msg = JSON.parse(message)
-        if (msg.signal) {
-          callback(msg.signal)
+      ws.on('message', (message: any) => {
+        if (message && message.signal) {
+          callback(message.signal)
         }
       })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
         if (!message) return
         const msg = JSON.parse(message)
         if (msg.signal) {
-          callback(msg.signal)
+          callback(msg)
         }
       })
     }

--- a/test/test.js
+++ b/test/test.js
@@ -135,7 +135,7 @@ describe('hc-web-client onSignal', () => {
     const testUrl = 'ws://localhost:3000'
     const { onSignal } = await connect({url: testUrl})
     onSignal((signal) => {
-      expect(signal).to.deep.equal({ signal_data: 'test signal data' })
+      expect(signal).to.deep.equal({ signal: { signal_data: 'test signal data' } })
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -89,3 +89,38 @@ describe('hc-web-client call', () => {
   })
 
 })
+
+describe('hc-web-client onSignal', () => {
+
+  beforeEach(() => {
+    sinon.stub(rpcws, 'Client').returns(
+      {
+        on: sinon.fake((on, callback) => {
+          if (on === 'message') {
+            return callback({signal: {
+              signal_data: 'test signal data'
+            }})
+          } else {
+            return callback()
+          }
+        }),
+        call: sinon.fake((method, params) => {
+          callMock(method, params)
+        }),
+      }
+    )
+  })
+
+  afterEach(() => {
+    rpcws.Client.restore();
+  });
+
+  it('returns a onSignal function which takes a closure to run when a signal message is received', async () => {
+    const testUrl = 'ws://localhost:3000'
+    const { onSignal } = await connect(testUrl)
+    onSignal((signal) => {
+      expect(signal).to.deep.equal({ signal_data: 'test signal data' })
+    })
+  })
+
+})

--- a/test/test.js
+++ b/test/test.js
@@ -96,14 +96,19 @@ describe('hc-web-client onSignal', () => {
     sinon.stub(rpcws, 'Client').returns(
       {
         on: sinon.fake((on, callback) => {
-          if (on === 'message') {
-            return callback({signal: {
-              signal_data: 'test signal data'
-            }})
-          } else {
-            return callback()
-          }
+          return callback()
         }),
+        socket: {
+          on: sinon.fake((on, callback) => {
+            if (on === 'message') {
+              return callback(JSON.stringify({signal: {
+                signal_data: 'test signal data'
+              }}))
+            } else {
+              return callback()
+            }
+          }),
+        },
         call: sinon.fake((method, params) => {
           callMock(method, params)
         }),


### PR DESCRIPTION
Adds an `onSignal` function which takes a closure and calls it when a message is received with a signal field.

This is probably not what the final interface will look like from the dev side since it requires manually filtering the signal content and dispatching the correct callback. In the future once the signal format has been standardized it might look more like `onSignal('directMessage', () => ...)`

Depends on holochain/holochain-rust#1365
