### PR TITLE
Use callWhenConnected for all calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "lint": "tslint -p tsconfig.json",
     "prepublishOnly": "npm test && npm run lint",
+    "prepare": "npm run build",
     "preversion": "npm run lint",
     "version": "git add -A src",
     "postversion": "git push && git push --tags",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ type ConnectOpts = {
  *       socket to be ready before timing out and rejecting the promise. Defaults to 5 seconds, but if you set it
  *       to 0 or null, it will never timeout.
  */
-export const connect = (opts: ConnectOpts) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
+export const connect = (opts: ConnectOpts = {}) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
   const url = opts.url || await getUrlFromContainer().catch(() => reject(
     'Could not auto-detect DNA interface from conductor. \
 Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,23 @@ type Close = () => Promise<any>
 type ConnectOpts = {
   url?: string,
   timeout?: number,
+  wsClient?: any,
 }
 
+/**
+ * Establish a websocket connection to a Conductor interface
+ * Accepts an object of options:
+ *   - url (optional): Specifies the URL to establish the connection with
+ *   - wsClient (optional): Object of options that gets passed through as configuration to the rpc-websockets client
+ *   - timeout (optional): If the socket is not ready, `call` and `callZome` will wait this many milliseconds for the
+ *       socket to be ready before timing out and rejecting the promise.
+ */
 export const connect = (opts: ConnectOpts) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
   const url = opts.url || await getUrlFromContainer().catch(() => reject(
     'Could not auto-detect DNA interface from conductor. \
 Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect'))
   const timeout = opts.timeout || DEFAULT_TIMEOUT
-  const ws = new Client(url)
+  const ws = new Client(url, opts.wsClient)
 
   ws.on('open', () => 'WS open')
   ws.on('close', () => 'WS closed')

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,14 @@ export const connect = (paramUrl?: string) => new Promise<{call: Call, callZome:
 Ensure the web UI is hosted by a Holochain Conductor or manually specify url as parameter to connect'))
 
   const ws = new Client(url)
-  ws.on('open', () => {
+
+  ws.on('open', () => 'WS open')
+  ws.on('close', () => 'WS closed')
+
+  ws.once('open', () => {
     const call = (...methodSegments) => (params) => {
       const method = methodSegments.length === 1 ? methodSegments[0] : methodSegments.join('/')
-      return ws.call(method, params)
+      return callWhenConnected(ws, method, params)
     }
     const callZome = (instanceId, zome, func) => (params) => {
       const callObject = {
@@ -25,7 +29,7 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
         'function': func,
         params
       }
-      return ws.call('call', callObject)
+      return callWhenConnected(ws, 'call', callObject)
     }
     const onSignal: OnSignal = (callback: (params: any) => void) => {
       // go down to the underlying websocket connection (.socket)
@@ -50,5 +54,26 @@ function getUrlFromContainer (): Promise<string> {
     .then(json => json.dna_interface.driver.port)
     .then(port => `ws://localhost:${port}`)
 }
+
+/**
+ * Ensure that a ws client never attempts to call when the socket is not ready
+ * Instead, return a promise that resolves only when the socket is connected and the call is made
+ */
+async function callWhenConnected (ws, method, payload, timeout=3000) {
+  if (ws.ready) {
+    return Promise.resolve(ws.call(method, payload))
+  } else {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(`Timeout while waiting for ws to connect. method: ${method}, payload: ${JSON.stringify(payload)}`)
+      }, timeout)
+      ws.once('open', () => {
+        clearTimeout(timer)
+        ws.call(method, payload).then(resolve).catch(reject)
+      })
+    })
+  }
+}
+
 
 const holochainclient = { connect }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ type ConnectOpts = {
  *   - url (optional): Specifies the URL to establish the connection with
  *   - wsClient (optional): Object of options that gets passed through as configuration to the rpc-websockets client
  *   - timeout (optional): If the socket is not ready, `call` and `callZome` will wait this many milliseconds for the
- *       socket to be ready before timing out and rejecting the promise.
+ *       socket to be ready before timing out and rejecting the promise. Defaults to 5 seconds, but if you set it
+ *       to 0 or null, it will never timeout.
  */
 export const connect = (opts: ConnectOpts) => new Promise<{call: Call, callZome: CallZome, close: Close, onSignal: OnSignal, ws: any}>(async (fulfill, reject) => {
   const url = opts.url || await getUrlFromContainer().catch(() => reject(


### PR DESCRIPTION
## Breaking change

Instead of `connect` taking an optional `url` string, it now takes an object, which lets you specify `url`, `timeout`, and `wsClient` options