### PR TITLE
Allow new instance_stats signals through filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,9 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
       ws.socket.on('message', (message: any) => {
         if (!message) return
         const msg = JSON.parse(message)
-        callback(msg)
+        if (msg.signal || msg.instance_stats) {
+          callback(msg)
+        }
       })
     }
     // define a function which will close the websocket connection

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,7 @@ Ensure the web UI is hosted by a Holochain Conductor or manually specify url as 
       ws.socket.on('message', (message: any) => {
         if (!message) return
         const msg = JSON.parse(message)
-        if (msg.signal) {
-          callback(msg)
-        }
+        callback(msg)
       })
     }
     // define a function which will close the websocket connection


### PR DESCRIPTION
The conductor now sends stats signals that don't have a `signal` property. hc-web-client should proxy those to the client.